### PR TITLE
Improve handling of SSL_CTX

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,23 @@ int main(int argc, char **argv) {
 ## "Hello World", Asynchronous HTTPS Server example.
 ```c
 int my_http_get_handler(short event, ad_conn_t *conn, void *userdata) {
-    if (ad_http_get_status(conn) == AD_HTTP_REQ_DONE) {
-        ad_http_response(conn, 200, "text/html", "Hello World", 11);
-        return ad_http_is_keepalive_request(conn) ? AD_DONE : AD_CLOSE;
+    if (event & AD_EVENT_READ) {
+        if (ad_http_get_status(conn) == AD_HTTP_REQ_DONE) {
+            ad_http_response(conn, 200, "text/html", "Hello World", 11);
+            return ad_http_is_keepalive_request(conn) ? AD_DONE : AD_CLOSE;
+        }
+        return AD_OK;
     }
     return AD_OK;
 }
 
 int my_http_default_handler(short event, ad_conn_t *conn, void *userdata) {
-    if (ad_http_get_status(conn) == AD_HTTP_REQ_DONE) {
-        ad_http_response(conn, 501, "text/html", "Not implemented", 15);
-        return AD_CLOSE; // Close connection.
+    if (event & AD_EVENT_READ) {
+        if (ad_http_get_status(conn) == AD_HTTP_REQ_DONE) {
+            ad_http_response(conn, 501, "text/html", "Not implemented", 15);
+            return AD_CLOSE; // Close connection.
+        }
+        return AD_OK;
     }
     return AD_OK;
 }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ int my_http_get_handler(short event, ad_conn_t *conn, void *userdata) {
             ad_http_response(conn, 200, "text/html", "Hello World", 11);
             return ad_http_is_keepalive_request(conn) ? AD_DONE : AD_CLOSE;
         }
-        return AD_OK;
     }
     return AD_OK;
 }
@@ -80,7 +79,6 @@ int my_http_default_handler(short event, ad_conn_t *conn, void *userdata) {
             ad_http_response(conn, 501, "text/html", "Not implemented", 15);
             return AD_CLOSE; // Close connection.
         }
-        return AD_OK;
     }
     return AD_OK;
 }

--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ int my_http_default_handler(short event, ad_conn_t *conn, void *userdata) {
 }
 
 int main(int argc, char **argv) {
+
+    SSL_load_error_strings();
+    SSL_library_init();
+
     ad_log_level(AD_LOG_DEBUG);
     ad_server_t *server = ad_server_new();
     ad_server_set_option(server, "server.port", "8888");
-    ad_server_set_option(server, "server.ssl_cert", "ssl.cert");
-    ad_server_set_option(server, "server.ssl_pkey", "ssl.pkey")
+    ad_server_set_ssl_ctx(server, ad_server_ssl_ctx_create_simple("ssl.cert", "ssl.pkey"));
     ad_server_register_hook(server, ad_http_handler, NULL); // HTTP Parser is also a hook.
     ad_server_register_hook_on_method(server, "GET", my_http_get_handler, NULL);
     ad_server_register_hook(server, my_http_default_handler, NULL);

--- a/examples/echo_http_server.c
+++ b/examples/echo_http_server.c
@@ -154,8 +154,8 @@ int main(int argc, char **argv) {
 
     // SSL option.
     //ad_server_set_option(server, "server.enable_ssl", "1");
-    //ad_server_set_option(server, "server.ssl_cert", "example.cert");
-    //ad_server_set_option(server, "server.ssl_pkey", "example.pkey");
+    //ad_server_set_option(server, "server.ssl_cert", "ssl.cert");
+    //ad_server_set_option(server, "server.ssl_pkey", "ssl.pkey");
 
     // Start server.
     int retstatus = ad_server_start(server);

--- a/examples/helloworld_http_server.c
+++ b/examples/helloworld_http_server.c
@@ -34,7 +34,6 @@ int my_http_get_handler(short event, ad_conn_t *conn, void *userdata) {
             ad_http_response(conn, 200, "text/html", "Hello World", 11);
             return ad_http_is_keepalive_request(conn) ? AD_DONE : AD_CLOSE;
         }
-        return AD_OK;
     }
     return AD_OK;
 }
@@ -45,7 +44,6 @@ int my_http_default_handler(short event, ad_conn_t *conn, void *userdata) {
             ad_http_response(conn, 501, "text/html", "Not implemented", 15);
             return AD_CLOSE; // Close connection.
         }
-        return AD_OK;
     }
     return AD_OK;
 }

--- a/examples/helloworld_http_server.c
+++ b/examples/helloworld_http_server.c
@@ -49,12 +49,13 @@ int my_http_default_handler(short event, ad_conn_t *conn, void *userdata) {
 }
 
 int main(int argc, char **argv) {
+    //SSL_load_error_strings();
+    //SSL_library_init();
     ad_log_level(AD_LOG_DEBUG);
     ad_server_t *server = ad_server_new();
     ad_server_set_option(server, "server.port", "8888");
-    //ad_server_set_option(server, "server.enable_ssl", "1");
-    //ad_server_set_option(server, "server.ssl_cert", "ssl.cert");
-    //ad_server_set_option(server, "server.ssl_pkey", "ssl.pkey");
+    //ad_server_set_ssl_ctx(server,
+    //        ad_server_ssl_ctx_create_simple("ssl.cert", "ssl.pkey"));
     ad_server_register_hook(server, ad_http_handler, NULL); // HTTP Parser is also a hook.
     ad_server_register_hook_on_method(server, "GET", my_http_get_handler, NULL);
     ad_server_register_hook(server, my_http_default_handler, NULL);

--- a/examples/helloworld_http_server.c
+++ b/examples/helloworld_http_server.c
@@ -29,17 +29,23 @@
 #include "asyncd/asyncd.h"
 
 int my_http_get_handler(short event, ad_conn_t *conn, void *userdata) {
-    if (ad_http_get_status(conn) == AD_HTTP_REQ_DONE) {
-        ad_http_response(conn, 200, "text/html", "Hello World", 11);
-        return ad_http_is_keepalive_request(conn) ? AD_DONE : AD_CLOSE;
+    if (event & AD_EVENT_READ) {
+        if (ad_http_get_status(conn) == AD_HTTP_REQ_DONE) {
+            ad_http_response(conn, 200, "text/html", "Hello World", 11);
+            return ad_http_is_keepalive_request(conn) ? AD_DONE : AD_CLOSE;
+        }
+        return AD_OK;
     }
     return AD_OK;
 }
 
 int my_http_default_handler(short event, ad_conn_t *conn, void *userdata) {
-    if (ad_http_get_status(conn) == AD_HTTP_REQ_DONE) {
-        ad_http_response(conn, 501, "text/html", "Not implemented", 15);
-        return AD_CLOSE; // Close connection.
+    if (event & AD_EVENT_READ) {
+        if (ad_http_get_status(conn) == AD_HTTP_REQ_DONE) {
+            ad_http_response(conn, 501, "text/html", "Not implemented", 15);
+            return AD_CLOSE; // Close connection.
+        }
+        return AD_OK;
     }
     return AD_OK;
 }
@@ -48,6 +54,9 @@ int main(int argc, char **argv) {
     ad_log_level(AD_LOG_DEBUG);
     ad_server_t *server = ad_server_new();
     ad_server_set_option(server, "server.port", "8888");
+    //ad_server_set_option(server, "server.enable_ssl", "1");
+    //ad_server_set_option(server, "server.ssl_cert", "ssl.cert");
+    //ad_server_set_option(server, "server.ssl_pkey", "ssl.pkey");
     ad_server_register_hook(server, ad_http_handler, NULL); // HTTP Parser is also a hook.
     ad_server_register_hook_on_method(server, "GET", my_http_get_handler, NULL);
     ad_server_register_hook(server, my_http_default_handler, NULL);

--- a/examples/helloworld_ssl_server.c
+++ b/examples/helloworld_ssl_server.c
@@ -38,12 +38,13 @@ int my_conn_handler(short event, ad_conn_t *conn, void *userdata) {
 }
 
 int main(int argc, char **argv) {
+    SSL_load_error_strings();
+    SSL_library_init();
     ad_log_level(AD_LOG_DEBUG);
     ad_server_t *server = ad_server_new();
     ad_server_set_option(server, "server.port", "2222");
-    ad_server_set_option(server, "server.enable_ssl", "1");
-    ad_server_set_option(server, "server.ssl_cert", "ssl.cert");
-    ad_server_set_option(server, "server.ssl_pkey", "ssl.pkey");
+    ad_server_set_ssl_ctx(server,
+            ad_server_ssl_ctx_create_simple("ssl.cert", "ssl.pkey"));
     ad_server_register_hook(server, my_conn_handler, NULL);
     return ad_server_start(server);
 }

--- a/include/asyncd/ad_server.h
+++ b/include/asyncd/ad_server.h
@@ -89,6 +89,11 @@ enum ad_log_e {
         /* Set read timeout seconds. 0 means no timeout. */                 \
         { "server.timeout",     "0" },                                      \
                                                                             \
+        /* SSL options */                                                   \
+        { "server.enable_ssl", "0" },                                       \
+        { "server.ssl_cert", "/usr/local/etc/ad_server/ad_server.crt" },    \
+        { "server.ssl_pkey", "/usr/local/etc/ad_server/ad_server.key" },    \
+                                                                            \
         /* Enable or disable request pipelining, this change AD_DONE's behavior */ \
         { "server.request_pipelining", "1" },                               \
                                                                             \

--- a/include/asyncd/ad_server.h
+++ b/include/asyncd/ad_server.h
@@ -89,11 +89,6 @@ enum ad_log_e {
         /* Set read timeout seconds. 0 means no timeout. */                 \
         { "server.timeout",     "0" },                                      \
                                                                             \
-        /* SSL options */                                                   \
-        { "server.enable_ssl", "0" },                                       \
-        { "server.ssl_cert", "/usr/local/etc/ad_server/ad_server.crt" },    \
-        { "server.ssl_pkey", "/usr/local/etc/ad_server/ad_server.key" },    \
-                                                                            \
         /* Enable or disable request pipelining, this change AD_DONE's behavior */ \
         { "server.request_pipelining", "1" },                               \
                                                                             \
@@ -182,6 +177,8 @@ extern void ad_server_global_free(void);
 extern void ad_server_set_option(ad_server_t *server, const char *key, const char *value);
 extern char *ad_server_get_option(ad_server_t *server, const char *key);
 extern int ad_server_get_option_int(ad_server_t *server, const char *key);
+extern SSL_CTX *ad_server_ssl_ctx_create_simple(const char *cert_path, const char *pkey_path);
+extern void ad_server_set_ssl_ctx(ad_server_t *server, SSL_CTX *sslctx);
 extern SSL_CTX *ad_server_get_ssl_ctx(ad_server_t *server);
 extern qhashtbl_t *ad_server_get_stats(ad_server_t *server, const char *key);
 


### PR DESCRIPTION
This is proposed improvement for handling SSL_CTX as described in issue #6. I updated ad_server.c as well as samples and the documentation. 

There are two commits here:

1. The first one (5e824e2) removes old functionality and replaces it with the new one. This is the cleanest approach but it breaks backward compatibility for existing code that uses HTTPS.
2. The second one (3b2a0cf) re-introduces the old behavior and makes the code backward compatible but leaves undesirable artefacts.

I leave it up to you to choose what approach you like better, so merge at will :smile: 

> Note: that this patch  overlaps with one I made for issue #5, so please review and apply the #5 first.