### PR TITLE
Add -D_FILE_OFFSET_BITS=64 flag to Makefile

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -64,7 +64,7 @@ SLIBNAME_LINK	= libasyncd.so
 CC		= gcc -std=gnu99
 CFLAGS		= -Wall -Wstrict-prototypes -fPIC -g -O2
 CPPFLAGS	+=  -I/usr/include -I/usr/local/include \
-		   -D_GNU_SOURCE -DBUILD_DEBUG 
+		   -D_GNU_SOURCE -DBUILD_DEBUG -D_FILE_OFFSET_BITS=64
 LIBS		+= @DEPLIBS@
 
 ## Make Library


### PR DESCRIPTION
Some places like https://github.com/wolkykim/libasyncd/blob/40768e1adc67c9fc700541a9a69166b45e78f403/src/ad_http_handler.c#L279 are assuming that `off_t` is 64bits which by default is not the case when compiling on 32 bits. Adding `-D_FILE_OFFSET_BITS=64` to the `Makefile.in`.

Without it, `Content-Length` (to name one) is broken:

```bash
$ curl -I http://localhost:1337
HTTP/1.1 200 OK
Content-Length: 47244640258
Content-Type: text/plain
Connection: Keep-Alive
```