### PR TITLE
Added rudimentary support for the BSD and Mac OS family of operating …

### DIFF
--- a/src/ad_server.c
+++ b/src/ad_server.c
@@ -41,7 +41,6 @@
 #include <assert.h>
 #include <sys/un.h>
 #include <sys/socket.h>
-#include <sys/eventfd.h>
 #include <event2/event.h>
 #include <event2/bufferevent.h>
 #include <event2/bufferevent_ssl.h>
@@ -55,6 +54,12 @@
 #include "macro.h"
 #include "qlibc/qlibc.h"
 #include "ad_server.h"
+
+#ifdef __linux__
+#include <sys/eventfd.h>
+#else
+#include <sys/event.h>
+#endif
 
 #ifndef _DOXYGEN_SKIP
 /*
@@ -229,7 +234,11 @@ int ad_server_start(ad_server_t *server) {
     }
 
     // Create a eventfd for notification channel.
+#ifdef __linux__
     int notifyfd = eventfd(0, 0);
+#else
+    int notifyfd = kqueue();
+#endif
     server->notify_buffer = bufferevent_socket_new(server->evbase, notifyfd, BEV_OPT_CLOSE_ON_FREE);
     bufferevent_setcb(server->notify_buffer, NULL, notify_cb, NULL, server);
 


### PR DESCRIPTION
…systems. Currently uses ifdef's; future revisions may abstract into an interface.

This change was tested on FreeBSD and Arch Linux. The Linux version still uses eventfd as before, but the BSD version uses kqueue, which in theory is supported across FreeBSD, NetBSD and OpenBSD as well as Mac OS X.