### PR TITLE
Update ad_server_ssl_ctx_create_simple()

### DIFF
--- a/src/ad_server.c
+++ b/src/ad_server.c
@@ -405,7 +405,7 @@ SSL_CTX *ad_server_ssl_ctx_create_simple(const char *cert_path,
         const char *pkey_path) {
     
     SSL_CTX *sslctx = SSL_CTX_new(SSLv23_server_method());
-    if (! SSL_CTX_use_certificate_file(sslctx, cert_path, SSL_FILETYPE_PEM) ||
+    if (! SSL_CTX_use_certificate_chain_file(sslctx, cert_path) ||
         ! SSL_CTX_use_PrivateKey_file(sslctx, pkey_path, SSL_FILETYPE_PEM)) {
         
         ERROR("Couldn't load certificate file(%s) or private key file(%s).",


### PR DESCRIPTION
> SSL_CTX_use_certificate_chain_file() should be used instead of the SSL_CTX_use_certificate_file() function in order to allow the use of complete certificate chains even when no trusted CA storage is used or when the CA issuing the certificate shall not be added to the trusted CA storage.

According to [OpenSSL docs](https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_use_certificate.html).